### PR TITLE
Cbio workflow restart

### DIFF
--- a/prefect.yaml
+++ b/prefect.yaml
@@ -161,7 +161,7 @@ deployments:
   entrypoint: workflows/restart-ecs-service.py:restart_backend_ecs_service
   parameters: {}
   work_pool:
-    name: cbio-8gb-prefect-3.2.14-python3.9
+    name: ccdi-dcc-16gb-prefect-3.2.14-python3.9
     work_queue_name:
     job_variables: {}
   schedules: []
@@ -189,7 +189,7 @@ deployments:
   entrypoint: workflows/restart-ecs-service.py:restart_backend_ecs_service
   parameters: {}
   work_pool:
-    name: cbio-8gb-prod-prefect-3.2.14-python3.9
+    name: ccdi-dcc-16gb-prefect-3.2.14-python3.9
     work_queue_name:
     job_variables: {}
   schedules: []

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -172,7 +172,7 @@ deployments:
   - prefect.deployments.steps.git_clone:
       id: clone-step
       repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-cBioPortal-Workflows.git
-      branch: cbio-workflow-restart
+      branch: main
   - prefect.deployments.steps.pip_install_requirements:
       requirements_file: requirements.txt
       directory: "{{ clone-step.directory }}"
@@ -200,7 +200,7 @@ deployments:
   - prefect.deployments.steps.git_clone:
       id: clone-step
       repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-cBioPortal-Workflows.git
-      branch: cbio-workflow-restart
+      branch: main
   - prefect.deployments.steps.pip_install_requirements:
       requirements_file: requirements.txt
       directory: "{{ clone-step.directory }}"

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -40,7 +40,7 @@ deployments:
     job_variables: {}
   schedules: []
 
-- name: TEST-cbio-mysql-restore
+- name: cbio-mysql-restore
   version: null
   tags:
   - mysql
@@ -70,7 +70,7 @@ deployments:
   - prefect.deployments.steps.git_clone:
       id: clone-step
       repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-cBioPortal-Workflows.git
-      branch: cbio-workflow-restart
+      branch: main
   - prefect.deployments.steps.pip_install_requirements:
       requirements_file: requirements.txt
       directory: "{{ clone-step.directory }}"

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -40,7 +40,7 @@ deployments:
     job_variables: {}
   schedules: []
 
-- name: cbio-mysql-restore
+- name: TEST-cbio-mysql-restore
   version: null
   tags:
   - mysql
@@ -56,7 +56,7 @@ deployments:
     output_bucket: "cbio-backup-qa"
     output_path: ""
   work_pool:
-    name: cbio-8gb-prefect-3.2.14-python3.9
+    name: ccdi-dcc-16gb-prefect-3.2.14-python3.9
     work_queue_name:
     job_variables: {}
   schedules: []
@@ -70,7 +70,7 @@ deployments:
   - prefect.deployments.steps.git_clone:
       id: clone-step
       repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-cBioPortal-Workflows.git
-      branch: main
+      branch: cbio-workflow-restart
   - prefect.deployments.steps.pip_install_requirements:
       requirements_file: requirements.txt
       directory: "{{ clone-step.directory }}"

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -172,7 +172,7 @@ deployments:
   - prefect.deployments.steps.git_clone:
       id: clone-step
       repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-cBioPortal-Workflows.git
-      branch: main
+      branch: cbio-workflow-restart
   - prefect.deployments.steps.pip_install_requirements:
       requirements_file: requirements.txt
       directory: "{{ clone-step.directory }}"
@@ -200,7 +200,7 @@ deployments:
   - prefect.deployments.steps.git_clone:
       id: clone-step
       repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-cBioPortal-Workflows.git
-      branch: main
+      branch: cbio-workflow-restart
   - prefect.deployments.steps.pip_install_requirements:
       requirements_file: requirements.txt
       directory: "{{ clone-step.directory }}"

--- a/src/utils.py
+++ b/src/utils.py
@@ -10,6 +10,13 @@ from botocore.exceptions import ClientError
 import logging
 
 
+@task(name="Log AWS Caller Identity")
+def log_aws_identity():
+    logger = get_run_logger()
+    sts = boto3.client("sts")
+    identity = sts.get_caller_identity()
+    logger.info(f"AWS Caller Identity: {identity}")
+
 def get_time() -> str:
     """Returns the current time"""
     tz = timezone("EST")
@@ -267,6 +274,7 @@ def db_counter(db_type: str, dump_file: str = None):
     Returns:
         pd.DataFrame: DataFrame containing table names, column counts, and row counts.
     """
+    log_aws_identity()
     if db_type == "dump": 
     
         # Check if dump_file is provided

--- a/src/utils.py
+++ b/src/utils.py
@@ -66,8 +66,6 @@ def get_secret(env_name: str):
         
     # update secret name for centralized workers
     secret_name = f"arn:aws:secretsmanager:{region_name}:{account_id}:secret:{secret_name}"
-    
-    print(f"Retrieving secret from path: {secret_name}")
         
     # Create a Secrets Manager client
     session = boto3.session.Session()

--- a/src/utils.py
+++ b/src/utils.py
@@ -35,7 +35,7 @@ def set_s3_resource():
         s3_resource = boto3.resource("s3")
     return s3_resource
 
-@task(name="get_secret")
+@task(name="get_secret", log_prints=True)
 def get_secret(env_name: str):
     """Get the secret from AWS Secrets Manager.
 
@@ -51,6 +51,7 @@ def get_secret(env_name: str):
     """
 
     region_name = "us-east-1"
+    account_id = "864981743430"
 
     if env_name == "dev":
         secret_name = "ccdicbio-dev-rds"
@@ -63,10 +64,15 @@ def get_secret(env_name: str):
     else:
         raise ValueError("Invalid environment name. Please use one of: ['dev', 'qa', 'stage', 'prod'].")
         
+    # update secret name for centralized workers
+    secret_name = f"arn:aws:secretsmanager:{region_name}:{account_id}:secret:{secret_name}"
+    
+    print(f"Retrieving secret from path: {secret_name}")
+        
     # Create a Secrets Manager client
     session = boto3.session.Session()
     client = session.client(service_name="secretsmanager", region_name=region_name)
-
+    
     # retreive the secret
     try:
         get_secret_value_response = client.get_secret_value(SecretId=secret_name)

--- a/src/utils.py
+++ b/src/utils.py
@@ -476,12 +476,12 @@ def upload_folder_to_s3(
 def restart_ecs_service(env_name: str):
     logger = get_run_logger()
     log_aws_identity(logger)
-    cluster_name = f"cbio-{env_name}-Cluster"
-    service_name = f"cbio-{env_name}-Fargate-Service"
+    env = env_name.lower()
+    cluster_name = f"cbio-{env}-Cluster"
+    service_name = f"cbio-{env}-Fargate-Service"
 
     sts = boto3.client("sts")
 
-    env = env_name.lower()
     if env in ("prod" ,"stage"):
         assumed_role = sts.assume_role(
             RoleArn="arn:aws:iam::195275671594:role/power-user-prefect-ecs-task-manager-cBioportal-curation-prod",

--- a/src/utils.py
+++ b/src/utils.py
@@ -10,11 +10,6 @@ from botocore.exceptions import ClientError
 import logging
 
 
-def log_aws_identity(logger):
-    sts = boto3.client("sts")
-    identity = sts.get_caller_identity()
-    logger.info(f"AWS Caller Identity: {identity}")
-
 def get_time() -> str:
     """Returns the current time"""
     tz = timezone("EST")
@@ -475,7 +470,6 @@ def upload_folder_to_s3(
 @task(name="Restart ECS Service Task", retries=3, retry_delay_seconds=30)
 def restart_ecs_service(env_name: str):
     logger = get_run_logger()
-    log_aws_identity(logger)
     env = env_name.lower()
     cluster_name = f"cbio-{env}-Cluster"
     service_name = f"cbio-{env}-Fargate-Service"

--- a/src/utils.py
+++ b/src/utils.py
@@ -481,11 +481,17 @@ def restart_ecs_service(env_name: str):
 
     sts = boto3.client("sts")
 
-    assumed_role = sts.assume_role(
-        RoleArn="arn:aws:iam::864981743430:role/power-user-prefect-ecs-task-manager-cBioportal-curation",
-        RoleSessionName="prefect-ecs-restart"
-    )
-
+    if env_name == "prod":
+        assumed_role = sts.assume_role(
+            RoleArn="arn:aws:iam::864981743430:role/power-user-prefect-ecs-task-cBioportal-curation",
+            RoleSessionName="prefect-ecs-restart"
+        )
+    else:
+        assumed_role = sts.assume_role(
+            RoleArn="arn:aws:iam::864981743430:role/power-user-prefect-ecs-task-manager-cBioportal-curation",
+            RoleSessionName="prefect-ecs-restart"
+        )
+    
     creds = assumed_role["Credentials"]
 
     ecs_client = boto3.client(

--- a/src/utils.py
+++ b/src/utils.py
@@ -478,8 +478,23 @@ def restart_ecs_service(env_name: str):
     log_aws_identity(logger)
     cluster_name = f"cbio-{env_name}-Cluster"
     service_name = f"cbio-{env_name}-Fargate-Service"
-    
-    ecs_client = boto3.client('ecs')
+
+    sts = boto3.client("sts")
+
+    assumed_role = sts.assume_role(
+        RoleArn="arn:aws:iam::864981743430:role/power-user-prefect-ecs-task-manager-cBioportal-curation",
+        RoleSessionName="prefect-ecs-restart"
+    )
+
+    creds = assumed_role["Credentials"]
+
+    ecs_client = boto3.client(
+        "ecs",
+        region_name="us-east-1",
+        aws_access_key_id=creds["AccessKeyId"],
+        aws_secret_access_key=creds["SecretAccessKey"],
+        aws_session_token=creds["SessionToken"]
+    )
     
     logger.info(f"Attempting to force new deployment (restart) for: {service_name} on Cluster: {cluster_name}")
     

--- a/src/utils.py
+++ b/src/utils.py
@@ -267,7 +267,6 @@ def db_counter(db_type: str, dump_file: str = None):
     Returns:
         pd.DataFrame: DataFrame containing table names, column counts, and row counts.
     """
-    log_aws_identity()
     if db_type == "dump": 
     
         # Check if dump_file is provided

--- a/src/utils.py
+++ b/src/utils.py
@@ -11,7 +11,6 @@ import logging
 
 
 def log_aws_identity(logger):
-    logger = get_run_logger()
     sts = boto3.client("sts")
     identity = sts.get_caller_identity()
     logger.info(f"AWS Caller Identity: {identity}")

--- a/src/utils.py
+++ b/src/utils.py
@@ -481,9 +481,9 @@ def restart_ecs_service(env_name: str):
 
     sts = boto3.client("sts")
 
-    if env_name == "prod":
+    if env_name == "prod" or "stage":
         assumed_role = sts.assume_role(
-            RoleArn="arn:aws:iam::864981743430:role/power-user-prefect-ecs-task-cBioportal-curation",
+            RoleArn="arn:aws:iam::195275671594:role/power-user-prefect-ecs-task-manager-cBioportal-curation-prod",
             RoleSessionName="prefect-ecs-restart"
         )
     else:

--- a/src/utils.py
+++ b/src/utils.py
@@ -476,6 +476,7 @@ def upload_folder_to_s3(
 
 @task(name="Restart ECS Service Task", retries=3, retry_delay_seconds=30)
 def restart_ecs_service(env_name: str):
+    log_aws_identity()
     logger = get_run_logger()
     
     cluster_name = f"cbio-{env_name}-Cluster"
@@ -523,7 +524,7 @@ def process_dump_file(dump_file_name: str) -> bool:
         bool: Whether processing was successful.
     """
     #remove CREATE DATABASE AND USE statements to exclude source db schema calls
-    #rename dump file to raw_{dump_file_name}
+    #rename dump file to raw_{dump_file_name
     raw_dump_file_name = f"raw_{dump_file_name}" 
     os.rename(dump_file_name, raw_dump_file_name)
     pattern = re.compile(r"USE |CREATE DATABASE ")

--- a/src/utils.py
+++ b/src/utils.py
@@ -483,6 +483,9 @@ def restart_ecs_service(env_name: str):
     service_name = f"cbio-{env_name}-Fargate-Service"
     
     ecs_client = boto3.client('ecs')
+    sts = boto3.client("sts")
+    identity = sts.get_caller_identity()
+    logger.info(f"AWS Caller Identity: {identity}")
     
     logger.info(f"Attempting to force new deployment (restart) for: {service_name} on Cluster: {cluster_name}")
     

--- a/src/utils.py
+++ b/src/utils.py
@@ -481,16 +481,19 @@ def restart_ecs_service(env_name: str):
 
     sts = boto3.client("sts")
 
-    if env_name == "prod" or "stage":
+    env = env_name.lower()
+    if env in ("prod" ,"stage"):
         assumed_role = sts.assume_role(
             RoleArn="arn:aws:iam::195275671594:role/power-user-prefect-ecs-task-manager-cBioportal-curation-prod",
             RoleSessionName="prefect-ecs-restart"
         )
-    else:
+    elif env in ("dev","qa"):
         assumed_role = sts.assume_role(
             RoleArn="arn:aws:iam::864981743430:role/power-user-prefect-ecs-task-manager-cBioportal-curation",
             RoleSessionName="prefect-ecs-restart"
         )
+    else :
+        raise ValueError(f"Invalid environment: {env_name}")
     
     creds = assumed_role["Credentials"]
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -10,8 +10,7 @@ from botocore.exceptions import ClientError
 import logging
 
 
-@task(name="Log AWS Caller Identity")
-def log_aws_identity():
+def log_aws_identity(logger):
     logger = get_run_logger()
     sts = boto3.client("sts")
     identity = sts.get_caller_identity()
@@ -476,16 +475,12 @@ def upload_folder_to_s3(
 
 @task(name="Restart ECS Service Task", retries=3, retry_delay_seconds=30)
 def restart_ecs_service(env_name: str):
-    log_aws_identity()
     logger = get_run_logger()
-    
+    log_aws_identity(logger)
     cluster_name = f"cbio-{env_name}-Cluster"
     service_name = f"cbio-{env_name}-Fargate-Service"
     
     ecs_client = boto3.client('ecs')
-    sts = boto3.client("sts")
-    identity = sts.get_caller_identity()
-    logger.info(f"AWS Caller Identity: {identity}")
     
     logger.info(f"Attempting to force new deployment (restart) for: {service_name} on Cluster: {cluster_name}")
     

--- a/src/utils.py
+++ b/src/utils.py
@@ -538,7 +538,7 @@ def process_dump_file(dump_file_name: str) -> bool:
         bool: Whether processing was successful.
     """
     #remove CREATE DATABASE AND USE statements to exclude source db schema calls
-    #rename dump file to raw_{dump_file_name
+    #rename dump file to raw_{dump_file_name}
     raw_dump_file_name = f"raw_{dump_file_name}" 
     os.rename(dump_file_name, raw_dump_file_name)
     pattern = re.compile(r"USE |CREATE DATABASE ")


### PR DESCRIPTION
Update the Prefect task to restart ECS service by assuming a cross-account role and forcing a new deployment on the target cluster and service for CBIO prod and non-prod.