### PR TITLE
Loader Patch

### DIFF
--- a/prefect.yaml
+++ b/prefect.yaml
@@ -318,10 +318,10 @@ deployments:
         apt install maven -y
       stream_output: true
       
-- name: TEST-cbio-dataset-load
+- name: cbio-dataset-load
   version: null
   tags:
-    - TEST
+    - PROD
     - mysql
     - cbioportal
     - V3
@@ -365,7 +365,7 @@ deployments:
   - prefect.deployments.steps.git_clone:
       id: clone-step
       repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-cBioPortal-Workflows.git
-      branch: load_patch2
+      branch: main
   - prefect.deployments.steps.pip_install_requirements:
       requirements_file: requirements.txt
       directory: "{{ clone-step.directory }}"

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -318,10 +318,10 @@ deployments:
         apt install maven -y
       stream_output: true
       
-- name: cbio-dataset-load
+- name: TEST-cbio-dataset-load
   version: null
   tags:
-    - PROD
+    - TEST
     - mysql
     - cbioportal
     - V3
@@ -365,7 +365,7 @@ deployments:
   - prefect.deployments.steps.git_clone:
       id: clone-step
       repository: https://github.com/CBIIT/ChildhoodCancerDataInitiative-cBioPortal-Workflows.git
-      branch: main
+      branch: load_patch2
   - prefect.deployments.steps.pip_install_requirements:
       requirements_file: requirements.txt
       directory: "{{ clone-step.directory }}"

--- a/workflows/cbio_dataset_load_remove.py
+++ b/workflows/cbio_dataset_load_remove.py
@@ -77,7 +77,7 @@ def validate_study(
     if return_code in [0, 3]:
         logger.info(f"Validation completed with code {return_code} (acceptable)")
     else:
-        logger.warning(f"Unexpected validation failure (code {return_code})")
+        logger.warning(f"Unexpected validation failure (code {result})")
 
     logger.info("Study validation process complete")
 
@@ -155,7 +155,7 @@ def import_study(
         )
         logger.info(f"Warning/error message: {msg}")
     else:
-        raise RuntimeError(f"Unexpected import failure (code {return_code})")
+        raise RuntimeError(f"Unexpected import failure (code {result})")
 
     logger.info("Study import process complete")
 

--- a/workflows/cbio_dataset_load_remove.py
+++ b/workflows/cbio_dataset_load_remove.py
@@ -53,7 +53,7 @@ def validate_study(
         ]
     else:
         cmd = [
-            f"python3 {importer_script} --study_directory {study_dir} --url_server https://cbioportal-api-dev.ccdi.cancer.gov/ --html {html_table_file_path} --error_file {error_file_path} -v "
+            f"python3 {importer_script} --study_directory {study_dir} --url_server https://cbioportal-api-dev.ccdi.cancer.gov --html {html_table_file_path} --error_file {error_file_path} -v "
         ]
 
     logger.info(f"Validating study: {study_dir}")
@@ -125,7 +125,7 @@ def import_study(
         ]
     else:
         cmd = [
-            f"python3 {importer_script} --study_directory {study_dir} --url_server https://cbioportal-api-dev.ccdi.cancer.gov/ --html {html_table_file_path} --override_warning --verbose "
+            f"python3 {importer_script} --study_directory {study_dir} --url_server https://cbioportal-api-dev.ccdi.cancer.gov --html {html_table_file_path} --override_warning --verbose "
         ]
 
     logger.info(f"Importing study: {study_dir}")

--- a/workflows/cbio_dataset_load_remove.py
+++ b/workflows/cbio_dataset_load_remove.py
@@ -49,11 +49,11 @@ def validate_study(
     if portal_info_dir and portal_info_dir != "":
         logger.info(f"Using portal info directory for validation: {portal_info_dir}")
         cmd = [
-                f"python3 {importer_script} --study_directory {study_dir} --portal_info_dir {portal_info_dir} --html {html_table_file_path} --error_file {error_file_path} -v "
+                f"python3 {importer_script} --study_directory {study_dir} --portal_info_dir {portal_info_dir} --html {html_table_file_path} --error_file {error_file_path} -v 1>output.log 2>output.log"
         ]
     else:
         cmd = [
-            f"python3 {importer_script} --study_directory {study_dir} --url_server https://cbioportal-api-dev.ccdi.cancer.gov --html {html_table_file_path} --error_file {error_file_path} -v "
+            f"python3 {importer_script} --study_directory {study_dir} --url_server https://cbioportal-api-dev.ccdi.cancer.gov --html {html_table_file_path} --error_file {error_file_path} -v 1>output.log 2>output.log"
         ]
 
     logger.info(f"Validating study: {study_dir}")
@@ -77,6 +77,9 @@ def validate_study(
     if return_code in [0, 3]:
         logger.info(f"Validation completed with code {return_code} (acceptable)")
     else:
+        error_strings = ["grep ERROR output.log"]
+        shell_op = ShellOperation(commands=error_strings)
+        result = shell_op.run()
         logger.warning(f"Unexpected validation failure (code {result})")
 
     logger.info("Study validation process complete")

--- a/workflows/cbio_dataset_load_remove.py
+++ b/workflows/cbio_dataset_load_remove.py
@@ -49,11 +49,11 @@ def validate_study(
     if portal_info_dir and portal_info_dir != "":
         logger.info(f"Using portal info directory for validation: {portal_info_dir}")
         cmd = [
-                f"python3 {importer_script} --study_directory {study_dir} --portal_info_dir {portal_info_dir} --html {html_table_file_path} --error_file {error_file_path} -v 2>/dev/null 1>/dev/null"
+                f"python3 {importer_script} --study_directory {study_dir} --portal_info_dir {portal_info_dir} --html {html_table_file_path} --error_file {error_file_path} -v "
         ]
     else:
         cmd = [
-            f"python3 {importer_script} --study_directory {study_dir} --url_server https://cbioportal-api-dev.ccdi.cancer.gov/ --html {html_table_file_path} --error_file {error_file_path} -v 2>/dev/null 1>/dev/null"
+            f"python3 {importer_script} --study_directory {study_dir} --url_server https://cbioportal-api-dev.ccdi.cancer.gov/ --html {html_table_file_path} --error_file {error_file_path} -v "
         ]
 
     logger.info(f"Validating study: {study_dir}")
@@ -121,11 +121,11 @@ def import_study(
     if portal_info_dir and portal_info_dir != "":
         logger.info(f"Using portal info directory for import: {portal_info_dir}")
         cmd = [
-                f"python3 {importer_script} --study_directory {study_dir} --portal_info_dir {portal_info_dir} --html {html_table_file_path} --override_warning --verbose 2>/dev/null 1>/dev/null"
+                f"python3 {importer_script} --study_directory {study_dir} --portal_info_dir {portal_info_dir} --html {html_table_file_path} --override_warning --verbose "
         ]
     else:
         cmd = [
-            f"python3 {importer_script} --study_directory {study_dir} --url_server https://cbioportal-api-dev.ccdi.cancer.gov/ --html {html_table_file_path} --override_warning --verbose 2>/dev/null 1>/dev/null"
+            f"python3 {importer_script} --study_directory {study_dir} --url_server https://cbioportal-api-dev.ccdi.cancer.gov/ --html {html_table_file_path} --override_warning --verbose "
         ]
 
     logger.info(f"Importing study: {study_dir}")

--- a/workflows/cbio_dataset_load_remove.py
+++ b/workflows/cbio_dataset_load_remove.py
@@ -80,7 +80,7 @@ def validate_study(
         error_strings = ["grep ERROR output.log"]
         shell_op = ShellOperation(commands=error_strings)
         result = shell_op.run()
-        logger.warning(f"Unexpected validation failure (code {result})")
+        logger.error(f"Unexpected validation failure (code {result})")
 
     logger.info("Study validation process complete")
 
@@ -124,11 +124,11 @@ def import_study(
     if portal_info_dir and portal_info_dir != "":
         logger.info(f"Using portal info directory for import: {portal_info_dir}")
         cmd = [
-                f"python3 {importer_script} --study_directory {study_dir} --portal_info_dir {portal_info_dir} --html {html_table_file_path} --override_warning --verbose "
+                f"python3 {importer_script} --study_directory {study_dir} --portal_info_dir {portal_info_dir} --html {html_table_file_path} --override_warning --verbose 2>output.log 1>output.log"
         ]
     else:
         cmd = [
-            f"python3 {importer_script} --study_directory {study_dir} --url_server https://cbioportal-api-dev.ccdi.cancer.gov --html {html_table_file_path} --override_warning --verbose "
+            f"python3 {importer_script} --study_directory {study_dir} --url_server https://cbioportal-api-dev.ccdi.cancer.gov --html {html_table_file_path} --override_warning --verbose 2>output.log 1>output.log"
         ]
 
     logger.info(f"Importing study: {study_dir}")
@@ -158,6 +158,10 @@ def import_study(
         )
         logger.info(f"Warning/error message: {msg}")
     else:
+        error_strings = ["grep ERROR output.log"]
+        shell_op = ShellOperation(commands=error_strings)
+        result = shell_op.run()
+        logger.error(f"Unexpected validation failure (code {result})")
         raise RuntimeError(f"Unexpected import failure (code {result})")
 
     logger.info("Study import process complete")


### PR DESCRIPTION
Direct standard outputs and standard errors to a local file that is then used to record and pull pertinent error messages to logging for failed loads and validation runs.